### PR TITLE
Update HailstormModule.java

### DIFF
--- a/src/main/java/xenoscape/worldsretold/hailstorm/HailstormModule.java
+++ b/src/main/java/xenoscape/worldsretold/hailstorm/HailstormModule.java
@@ -15,7 +15,8 @@ public class HailstormModule {
 	public static HailstormModule INSTANCE = new HailstormModule();
 
 	public void preInitHailstorm(FMLPreInitializationEvent event) {
-        MinecraftForge.EVENT_BUS.register(new HailstormClientEvents());
+		if(event.getSide().isClient())
+        		MinecraftForge.EVENT_BUS.register(new HailstormClientEvents());
 		MinecraftForge.EVENT_BUS.register(new HailstormVanillaLootInsertion());
 		HailstormEntities.preInit();
 		HailstormConfig.preInitConfigs(event);


### PR DESCRIPTION
Makes the client event handler only register on the client, as opposed to register on both sides.